### PR TITLE
Add parks learning topic

### DIFF
--- a/learning/parks.md
+++ b/learning/parks.md
@@ -1,0 +1,7 @@
+# Parks
+
+## Golden Gate Park
+Golden Gate Park stretches over three miles in San Francisco, transforming former sand dunes into a long ribbon of greenery. Construction began in the 1870s under engineer William Hammond Hall and gardener John McLaren, who shaped the linear park to provide residents with a scenic escape and hosted world fairs, museums, and recreation.
+
+## Central Park
+Central Park spans about two and a half miles through the heart of Manhattan. Designed by Frederick Law Olmsted and Calvert Vaux, the park was built between 1857 and 1876 to give New Yorkers an elongated landscape of meadows, lakes, and wooded paths. Its long rectangular form set a model for urban park design.


### PR DESCRIPTION
## Summary
- add `learning/parks.md` covering Golden Gate Park and Central Park as elongated parks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892197ee1d48329865552ed3fc631ef